### PR TITLE
Add authentication endpoints for user registration and login

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NextParkAPI.Data;
+using NextParkAPI.Models;
+using NextParkAPI.Models.Requests;
+using NextParkAPI.Utils;
+
+namespace NextParkAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly NextParkContext _context;
+
+        public AuthController(NextParkContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Registra um novo usuário na plataforma.
+        /// </summary>
+        [HttpPost("register")]
+        public async Task<IActionResult> Register([FromBody] RegisterRequest request)
+        {
+            if (await _context.Usuarios.AnyAsync(u => u.NrEmail == request.Email))
+            {
+                return Conflict(new { message = "E-mail já cadastrado." });
+            }
+
+            var usuario = new Usuario
+            {
+                NrEmail = request.Email
+            };
+
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                _context.Usuarios.Add(usuario);
+                await _context.SaveChangesAsync();
+
+                var login = new Login
+                {
+                    IdUsuario = usuario.IdUsuario,
+                    NrEmail = request.Email,
+                    DsSenha = PasswordHasher.HashPassword(request.Password)
+                };
+
+                _context.Logins.Add(login);
+                await _context.SaveChangesAsync();
+
+                await transaction.CommitAsync();
+
+                return CreatedAtAction(nameof(Register), new
+                {
+                    message = "Usuário registrado com sucesso.",
+                    usuarioId = usuario.IdUsuario,
+                    email = usuario.NrEmail
+                });
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Realiza o login de um usuário existente.
+        /// </summary>
+        [HttpPost("login")]
+        public async Task<IActionResult> Login([FromBody] LoginRequest request)
+        {
+            var login = await _context.Logins
+                .AsNoTracking()
+                .FirstOrDefaultAsync(l => l.NrEmail == request.Email);
+
+            if (login is null)
+            {
+                return Unauthorized(new { message = "E-mail ou senha inválidos." });
+            }
+
+            var passwordValid = PasswordHasher.VerifyPassword(request.Password, login.DsSenha);
+            if (!passwordValid)
+            {
+                return Unauthorized(new { message = "E-mail ou senha inválidos." });
+            }
+
+            return Ok(new
+            {
+                message = "Login realizado com sucesso.",
+                usuarioId = login.IdUsuario,
+                email = login.NrEmail
+            });
+        }
+    }
+}

--- a/Data/Migrations/NextParkContextModelSnapshot.cs
+++ b/Data/Migrations/NextParkContextModelSnapshot.cs
@@ -55,6 +55,41 @@ namespace NextParkAPI.Data.Migrations
                     b.ToTable("TB_NEXTPARK_MANUTENCAO", (string)null);
                 });
 
+            modelBuilder.Entity("NextParkAPI.Models.Login", b =>
+                {
+                    b.Property<int>("IdLogin")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasColumnName("ID_LOGIN");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdLogin"));
+
+                    b.Property<string>("DsSenha")
+                        .IsRequired()
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)")
+                        .HasColumnName("DS_SENHA");
+
+                    b.Property<int>("IdUsuario")
+                        .HasColumnType("int")
+                        .HasColumnName("ID_USUARIO");
+
+                    b.Property<string>("NrEmail")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)")
+                        .HasColumnName("NR_EMAIL");
+
+                    b.HasKey("IdLogin");
+
+                    b.HasIndex("IdUsuario");
+
+                    b.HasIndex("NrEmail")
+                        .IsUnique();
+
+                    b.ToTable("TB_NEXTPARK_LOGIN", (string)null);
+                });
+
             modelBuilder.Entity("NextParkAPI.Models.Moto", b =>
                 {
                     b.Property<int>("IdMoto")
@@ -118,6 +153,29 @@ namespace NextParkAPI.Data.Migrations
                     b.ToTable("TB_NEXTPARK_VAGA", (string)null);
                 });
 
+            modelBuilder.Entity("NextParkAPI.Models.Usuario", b =>
+                {
+                    b.Property<int>("IdUsuario")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasColumnName("ID_USUARIO");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("IdUsuario"));
+
+                    b.Property<string>("NrEmail")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)")
+                        .HasColumnName("NR_EMAIL");
+
+                    b.HasKey("IdUsuario");
+
+                    b.HasIndex("NrEmail")
+                        .IsUnique();
+
+                    b.ToTable("TB_NEXTPARK_USUARIO", (string)null);
+                });
+
             modelBuilder.Entity("NextParkAPI.Models.Manutencao", b =>
                 {
                     b.HasOne("NextParkAPI.Models.Moto", null)
@@ -125,6 +183,22 @@ namespace NextParkAPI.Data.Migrations
                         .HasForeignKey("IdMoto")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("NextParkAPI.Models.Login", b =>
+                {
+                    b.HasOne("NextParkAPI.Models.Usuario", "Usuario")
+                        .WithMany("Logins")
+                        .HasForeignKey("IdUsuario")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Usuario");
+                });
+
+            modelBuilder.Entity("NextParkAPI.Models.Usuario", b =>
+                {
+                    b.Navigation("Logins");
                 });
 #pragma warning restore 612, 618
         }

--- a/Data/NextParkContext.cs
+++ b/Data/NextParkContext.cs
@@ -10,6 +10,8 @@ namespace NextParkAPI.Data
         public DbSet<Moto> Motos { get; set; }
         public DbSet<Vaga> Vagas { get; set; }
         public DbSet<Manutencao> Manutencoes { get; set; }
+        public DbSet<Usuario> Usuarios { get; set; }
+        public DbSet<Login> Logins { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -47,6 +49,36 @@ namespace NextParkAPI.Data
                 .WithMany()
                 .HasForeignKey(m => m.IdMoto)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Usuario>().ToTable("TB_NEXTPARK_USUARIO");
+
+            modelBuilder.Entity<Usuario>().HasKey(u => u.IdUsuario);
+
+            modelBuilder.Entity<Usuario>().Property(u => u.IdUsuario).HasColumnName("ID_USUARIO");
+            modelBuilder.Entity<Usuario>().Property(u => u.NrEmail).HasColumnName("NR_EMAIL").HasMaxLength(100);
+
+            modelBuilder.Entity<Usuario>()
+                .HasIndex(u => u.NrEmail)
+                .IsUnique();
+
+            modelBuilder.Entity<Login>().ToTable("TB_NEXTPARK_LOGIN");
+
+            modelBuilder.Entity<Login>().HasKey(l => l.IdLogin);
+
+            modelBuilder.Entity<Login>().Property(l => l.IdLogin).HasColumnName("ID_LOGIN");
+            modelBuilder.Entity<Login>().Property(l => l.IdUsuario).HasColumnName("ID_USUARIO");
+            modelBuilder.Entity<Login>().Property(l => l.NrEmail).HasColumnName("NR_EMAIL").HasMaxLength(100);
+            modelBuilder.Entity<Login>().Property(l => l.DsSenha).HasColumnName("DS_SENHA").HasMaxLength(255);
+
+            modelBuilder.Entity<Login>()
+                .HasIndex(l => l.NrEmail)
+                .IsUnique();
+
+            modelBuilder.Entity<Login>()
+                .HasOne(l => l.Usuario)
+                .WithMany(u => u.Logins)
+                .HasForeignKey(l => l.IdUsuario)
+                .OnDelete(DeleteBehavior.Cascade);
 
         }
 

--- a/Models/Login.cs
+++ b/Models/Login.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace NextParkAPI.Models
+{
+    [Table("TB_NEXTPARK_LOGIN")]
+    public class Login
+    {
+        [Key]
+        [Column("ID_LOGIN")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int IdLogin { get; set; }
+
+        [Required]
+        [Column("ID_USUARIO")]
+        public int IdUsuario { get; set; }
+
+        [Required]
+        [Column("NR_EMAIL")]
+        [MaxLength(100)]
+        public string NrEmail { get; set; } = string.Empty;
+
+        [Required]
+        [Column("DS_SENHA")]
+        [MaxLength(255)]
+        public string DsSenha { get; set; } = string.Empty;
+
+        public Usuario? Usuario { get; set; }
+    }
+}

--- a/Models/Requests/LoginRequest.cs
+++ b/Models/Requests/LoginRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NextParkAPI.Models.Requests
+{
+    public class LoginRequest
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Models/Requests/RegisterRequest.cs
+++ b/Models/Requests/RegisterRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NextParkAPI.Models.Requests
+{
+    public class RegisterRequest
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [MinLength(6)]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Models/Usuario.cs
+++ b/Models/Usuario.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace NextParkAPI.Models
+{
+    [Table("TB_NEXTPARK_USUARIO")]
+    public class Usuario
+    {
+        [Key]
+        [Column("ID_USUARIO")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int IdUsuario { get; set; }
+
+        [Required]
+        [Column("NR_EMAIL")]
+        [MaxLength(100)]
+        public string NrEmail { get; set; } = string.Empty;
+
+        public ICollection<Login> Logins { get; set; } = new List<Login>();
+    }
+}

--- a/Utils/PasswordHasher.cs
+++ b/Utils/PasswordHasher.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Security.Cryptography;
+
+namespace NextParkAPI.Utils
+{
+    public static class PasswordHasher
+    {
+        private const int SaltSize = 16;
+        private const int KeySize = 32;
+        private const int Iterations = 100_000;
+
+        public static string HashPassword(string password)
+        {
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentException("Password cannot be empty.", nameof(password));
+            }
+
+            using var rng = RandomNumberGenerator.Create();
+            var salt = new byte[SaltSize];
+            rng.GetBytes(salt);
+
+            var hash = DeriveKey(password, salt);
+            return $"{Convert.ToBase64String(salt)}.{Convert.ToBase64String(hash)}";
+        }
+
+        public static bool VerifyPassword(string password, string storedHash)
+        {
+            if (string.IsNullOrWhiteSpace(storedHash))
+            {
+                return false;
+            }
+
+            var parts = storedHash.Split('.');
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            try
+            {
+                var salt = Convert.FromBase64String(parts[0]);
+                var hash = Convert.FromBase64String(parts[1]);
+                var computedHash = DeriveKey(password, salt);
+                return CryptographicOperations.FixedTimeEquals(hash, computedHash);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+
+        private static byte[] DeriveKey(string password, byte[] salt)
+        {
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Iterations, HashAlgorithmName.SHA256);
+            return pbkdf2.GetBytes(KeySize);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Usuario and Login entity models plus a password hashing helper to represent credential tables
- implement an AuthController with registration and login endpoints backed by the new EF Core mappings
- update the EF Core model snapshot to include the new authentication entities

## Testing
- dotnet build *(fails: .NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db278658d08328938b601a5ab49a80